### PR TITLE
Linux fix

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -33,21 +33,20 @@ install_from_source () {
   fi
 
   cd $dirname \
-    `Install dependencies` \
+    `# Install dependencies` \
     && sh ./scripts/install_deps.sh \
-    `Build solc` \
+    `# Build solc` \
     && mkdir build \
     && cd build \
     && cmake .. \
     && make \
-    `Install the compiled solc` \
+    `# Install the compiled solc` \
     && mkdir $download_dir/bin \
     && cp solc/solc $download_dir/bin/ \
-    `Remove temporary files` \
+    `# Remove temporary files` \
     && cd $download_dir \
     && rm -rf $dirname \
     && rm $filename
-
 }
 
 # Downloads the prebuilt solc binary. Only for Linux.
@@ -64,7 +63,7 @@ install_static () {
   # Download and install solc
   mkdir $download_dir/bin \
     && wget -O $download_dir/bin/solc $release_url
-  
+
 }
 
 case $(uname -s) in

--- a/bin/install
+++ b/bin/install
@@ -57,7 +57,7 @@ install_static () {
   local download_dir=$2
 
   local base_url=https://github.com/ethereum/solidity/releases/download/
-  local filename=solc_static_linux
+  local filename=solc-static-linux
   local suffix=v$version/$filename
   local release_url=$base_url$suffix
 

--- a/bin/install
+++ b/bin/install
@@ -62,7 +62,7 @@ install_static () {
   local release_url=$base_url$suffix
 
   # Download and install solc
-  mkdir bin \
+  mkdir $download_dir/bin \
     && wget -O $download_dir/bin/solc $release_url
   
 }

--- a/bin/install
+++ b/bin/install
@@ -33,21 +33,17 @@ install_from_source () {
   fi
 
   cd $dirname \
-
-    # Install dependencies
+    `Install dependencies` \
     && sh ./scripts/install_deps.sh \
-
-    # Build solc
+    `Build solc` \
     && mkdir build \
     && cd build \
     && cmake .. \
     && make \
-
-    # Install the compiled solc
+    `Install the compiled solc` \
     && mkdir $download_dir/bin \
     && cp solc/solc $download_dir/bin/ \
-
-    # Remove temporary files
+    `Remove temporary files` \
     && cd $download_dir \
     && rm -rf $dirname \
     && rm $filename

--- a/bin/install
+++ b/bin/install
@@ -47,6 +47,7 @@ install_from_source () {
     && cd $download_dir \
     && rm -rf $dirname \
     && rm $filename
+
 }
 
 # Downloads the prebuilt solc binary. Only for Linux.
@@ -63,7 +64,7 @@ install_static () {
   # Download and install solc
   mkdir $download_dir/bin \
     && wget -O $download_dir/bin/solc $release_url
-
+  chmod +x $download_dir/bin/solc
 }
 
 case $(uname -s) in


### PR DESCRIPTION
This is a small collection of fixes for Linux.

1) comments in multiline commands doesn't seem to be supported under Linux. Please make sure it works well on OSX.
2) instead of creating /bin this directory is now created inside the $ASDF_INSTALL_PATH
3) filename was fixed dash (`-`) is used instead of underscore (`_`) as name part separator
4) chmod +x is used to make solc executable for the user who installed solidity